### PR TITLE
Allow passing in a typechain type to getContract functions

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -398,12 +398,12 @@ async function getContractFactoryByAbiAndBytecode(
   return new ContractFactory(abiWithAddedGas, bytecode, ethersSigner);
 }
 
-export async function getContractAt(
+export async function getContractAt<T extends ethers.Contract>(
   hre: HardhatRuntimeEnvironment,
   nameOrAbi: string | any[],
   address: string,
   signer?: ethers.Signer | string
-) {
+): Promise<T> {
   const { Contract } = require("ethers") as typeof ethers;
 
   if (typeof nameOrAbi === "string") {
@@ -414,7 +414,7 @@ export async function getContractAt(
       "0x",
       signer
     );
-    return factory.attach(address);
+    return factory.attach(address) as T;
   }
 
   const ethersSigner = await _getSigner(hre, signer);
@@ -424,26 +424,26 @@ export async function getContractAt(
     nameOrAbi
   );
 
-  return new Contract(address, abiWithAddedGas, ethersSigner || hre.ethers.provider);
+  return new Contract(address, abiWithAddedGas, ethersSigner || hre.ethers.provider) as T;
 }
 
-export async function getContract(
+export async function getContract<T extends ethers.Contract>(
   env: HardhatRuntimeEnvironment,
   contractName: string,
   signer?: ethers.Signer | string
-): Promise<ethers.Contract> {
-  const contract = await getContractOrNull(env, contractName, signer);
+): Promise<T> {
+  const contract = await getContractOrNull<T>(env, contractName, signer);
   if (contract === null) {
     throw new Error(`No Contract deployed with name ${contractName}`);
   }
   return contract;
 }
 
-export async function getContractOrNull(
+export async function getContractOrNull<T extends ethers.Contract>(
   env: HardhatRuntimeEnvironment,
   contractName: string,
   signer?: ethers.Signer | string
-): Promise<ethers.Contract | null> {
+): Promise<T | null> {
   const deployments = (env as any).deployments;
   if (deployments !== undefined) {
     const get = deployments.getOrNull;
@@ -451,7 +451,7 @@ export async function getContractOrNull(
     if (contract === undefined) {
       return null;
     }
-    return getContractAt(
+    return getContractAt<T>(
       env,
       contract.abi,
       contract.address,

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,11 @@ extendEnvironment((hre) => {
       // We cast to any here as we hit a limitation of Function#bind and
       // overloads. See: https://github.com/microsoft/TypeScript/issues/28582
       getContractFactory: getContractFactory.bind(null, hre) as any,
-      getContractAt: getContractAt.bind(null, hre),
+      getContractAt: async <T extends EthersT.Contract>(
+        nameOrAbi: string | any[],
+        address: string,
+        signer?: EthersT.Signer | string
+      )=> getContractAt<T>(hre, nameOrAbi, address, signer),
       
       getSigners: async () => getSigners(hre),
       getSigner: async(address) => getSigner(hre, address),
@@ -38,14 +42,14 @@ extendEnvironment((hre) => {
       getUnnamedSigners: async () => getUnnamedSigners(hre),
   
 
-      getContract: async (
-        name,
-        signer
-      ) => getContract(hre, name, signer),
-      getContractOrNull: async (
-        name,
-        signer
-      ) => getContractOrNull(hre, name, signer),
+      getContract: async <T extends EthersT.Contract>(
+        name: string,
+        signer?: EthersT.Signer | string
+      ) => getContract<T>(hre, name, signer),
+      getContractOrNull: async <T extends EthersT.Contract>(
+        name: string,
+        signer?: EthersT.Signer | string
+      ) => getContractOrNull<T>(hre, name, signer),
     };
   });
 });

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -28,11 +28,11 @@ declare module "hardhat/types/runtime" {
       provider: ethers.providers.JsonRpcProvider;
 
       getContractFactory: typeof getContractFactory;
-      getContractAt: (
+      getContractAt: <T extends ethers.Contract>(
         nameOrAbi: string | any[],
         address: string,
         signer?: ethers.Signer | string
-      ) => Promise<ethers.Contract>;
+      ) => Promise<T>;
       getSigners: () => Promise<SignerWithAddress[]>;
       getSigner: (address: string) => Promise<SignerWithAddress>;
       getSignerOrNull: (address: string) => Promise<SignerWithAddress | null>;
@@ -41,14 +41,14 @@ declare module "hardhat/types/runtime" {
       getNamedSignerOrNull: (name: string) => Promise<SignerWithAddress | null>;
       getUnnamedSigners: () => Promise<SignerWithAddress[]>;
 
-      getContract: (
+      getContract: <T extends ethers.Contract>(
         name: string,
         signer?: ethers.Signer | string
-      ) => Promise<ethers.Contract>;
-      getContractOrNull: (
+      ) => Promise<T>;
+      getContractOrNull: <T extends ethers.Contract>(
         name: string,
         signer?: ethers.Signer | string
-      ) => Promise<ethers.Contract | null>;
+      ) => Promise<T | null>;
       // Standard ethers properties
       Signer: typeof ethers.Signer;
       Wallet: typeof ethers.Wallet;


### PR DESCRIPTION
I find that quite often when I try to load a contract with the correct typechain type I have to do a cast which looks something like

```
const collateral = (await ethers.getContract("Collateral")) as Cash;
```

This seems quite ugly to me and would prefer this function being a generic where we can pass in any subtype of `ethers.Contract` and get that subtype out. This would change the above to something like

```
const collateral = await ethers.getContract<Cash>("Collateral");
```

This is much more readable in my opinion compared to having to await then cast. Of course if no type is provided then we get out an `ethers.Contract` type so it's backwards compatible for those who don't use this feature.

We could do something similar to the `getContractFactory` function but I wanted to gauge your opinion first.